### PR TITLE
Use host user HOME and USER

### DIFF
--- a/init_cluster/init_cluster.yaml
+++ b/init_cluster/init_cluster.yaml
@@ -17,9 +17,9 @@
     - name: copy admin.conf to user's kube config
       copy:
         src: /etc/kubernetes/admin.conf
-        dest: "{{ lookup('env','HOME') }}/.kube/config"
+        dest: "{{ ansible_env.HOME }}/.kube/config"
         remote_src: yes
-        owner: "{{ lookup('env','USER') }}"
+        owner: "{{ ansible_env.USER }}"
       become: yes
     
     - name: enable ability to schedule pods on the control-plane node (master)


### PR DESCRIPTION
@aporcupine

I know you suggest:
```
I’d recommend setting the username to the same as the user that you’re currently logged in to, otherwise you’ll need to add -u followed by the username to all subsequent Ansible calls.
```

But we could just use the host user `HOME` and `USER` as this will support both the use cases of ppl using the same username or a different one.

For example I use a different one and have in `.ssh/config`:
```
Host <HOSTNAME_PREFIX>*
    User <MY_USER>
```